### PR TITLE
 Upgrade Play to version 2.7.3 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,9 @@ scalaVersion := "2.12.8"
 
 crossScalaVersions := Seq("2.12.8", "2.11.12")
 
+resolvers += "Atlassian Releases" at "https://maven.atlassian.com/public/"
+resolvers += Resolver.bintrayRepo("jarlakxen", "maven")
+
 libraryDependencies += guice
 libraryDependencies += "com.iheart" %% "ficus" % "1.4.3"
 libraryDependencies += "com.mohiva" %% "play-silhouette" % "5.0.7"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ libraryDependencies += "com.mohiva" %% "play-silhouette" % "5.0.7"
 libraryDependencies += "com.mohiva" %% "play-silhouette-crypto-jca" % "5.0.7"
 libraryDependencies += "com.mohiva" %% "play-silhouette-persistence" % "5.0.7"
 libraryDependencies += "net.codingwell" %% "scala-guice" % "4.1.0"
-libraryDependencies += "software.amazon.awssdk" % "aws-sdk-java" % "2.5.66"
+libraryDependencies += "software.amazon.awssdk" % "aws-sdk-java" % "2.7.11"
 
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "4.0.2" % Test
 libraryDependencies +=  "com.github.jarlakxen" %% "drunk" % "2.5.0"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.2")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.7.3")


### PR DESCRIPTION
Upgrade to the latest version. This fixes the error:

```
akka.UnsupportedAkkaVersion: Current version of Akka is [2.5.22],
but akka-http requires version [2.5.23]
```

It's not clear what was causing that error, because it only occurred
on some developers machines, but upgrading Play seems to fix it.

Also upgrade the AWS SDK. This isn't strictly necessary, but we might as well use the latest version.