### PR TITLE
Temporarily remove deployment of master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,3 @@ scala:
 
 script:
   - sbt dist
-
-deploy:
-  provider: script
-  script: bash deploy.sh
-  on:
-branch: master


### PR DESCRIPTION
The deployment scripts are still a work-in-progress, so remove
the master deployment step until we need a continuous deployment
pipeline.