### PR TITLE
Deploy to dev env on master branch build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       #NOTE: Currently master branch will deploy to the development AWS environment for the purposes of Alpha
     - stage: "Deploy dev"
       script: scripts/deploy.sh dev
-      if: branch = develop
+      if: branch = master
     # - stage: deploytest
     #   script: scripts/deploy.sh test
     #   if: branch = test


### PR DESCRIPTION
Set build to deploy to AWS dev environment for master branch builds. Ensure that code changes to the protype mvc get deployed to AWS.