### PR TITLE
Use UUIDs as upload filenames rather than original filenames

### DIFF
--- a/js-src/aws/s3Upload.ts
+++ b/js-src/aws/s3Upload.ts
@@ -7,10 +7,15 @@ declare var TDR_USER_POOL_ID: string;
 declare var TDR_IDENTITY_POOL_ID: string;
 declare var S3_UPLOAD_BUCKET: string;
 
-export const uploadFiles = (files: File[]) => {
+export interface UploadableFile {
+    id: string,
+    file: File
+}
+
+export const uploadFiles = (files: UploadableFile[]) => {
     const currentUser = getCurrentUser();
     
-    if(!currentUser) {        
+    if(!currentUser) {
         // Placeholder error handling. In Beta, we should reauthenticate the user.
         return Promise.reject("No current user");        
     }
@@ -28,25 +33,26 @@ export const uploadFiles = (files: File[]) => {
        
         const userName = currentUser.getUsername();
         const bucket = S3_UPLOAD_BUCKET;
-        const s3Uploadkey = `${userName}-` + uuidv4();
+        // TODO: Use the consignment ID once known
+        const parentFolder = `${userName}-${uuidv4()}`;
         const s3 = new S3({
             params: {
                 Bucket: bucket
             }
         });
 
-        const uploads = files.map(file => uploadFile(s3, bucket, file.name, s3Uploadkey, file));
+        const uploads = files.map(fileDetails => uploadFile(s3, bucket, fileDetails.id, parentFolder, fileDetails.file));
 
         // If any uploads fail, this will only return the first error. We should handle ALL errors, not just the first.
         return Promise.all(uploads);
     });
 };
 
-function uploadFile(s3: S3, bucket: string, name: string, s3UploadKey: string, content: File): Promise<void> {
+function uploadFile(s3: S3, bucket: string, name: string, parentFolder: string, content: File): Promise<void> {
     return new Promise((resolve, reject) => {
         s3.upload(
             {
-                Key: `${s3UploadKey}/${name}`,
+                Key: `${parentFolder}/${name}`,
                 Bucket: bucket,
                 Body: content
             },

--- a/js-src/components/FileUpload.tsx
+++ b/js-src/components/FileUpload.tsx
@@ -47,12 +47,11 @@ export class FileUpload extends React.Component<FileUploadProps, FileUploadState
     }
 
     handleUpload(files: File[]) {
-        uploadFileMetadata(files).then(() => {          
-            return uploadFiles(files)
-        })
-            .then(() => {
-                this.setState({uploadedFileCount: files.length})
-            }).catch((error: any) => {
+        uploadFileMetadata(files).then((filesWithIds) => {
+            return uploadFiles(filesWithIds);
+        }).then(() => {
+            this.setState({uploadedFileCount: files.length})
+        }).catch((error: any) => {
             this.setState({uploadError: error});
             console.log("Error uploading file");
             console.log(error);

--- a/js-src/graphql/types/Files.ts
+++ b/js-src/graphql/types/Files.ts
@@ -1,5 +1,3 @@
-import { Consignments } from "./Consignments";
-
 // ====================================================
 // GraphQL query operation: Files
 // ====================================================
@@ -9,7 +7,7 @@ export interface Files_files {
     /**
      * The ID of an object
      */
-    id: number;
+    id: string;
     /**
      * The path of this File
      */
@@ -17,11 +15,11 @@ export interface Files_files {
     /**
      * The consignment of this File
      */
-    consignment: Consignments 
+    consignmentId: number;
   }
   
   export interface Files {
-    files: (Files_files | null)[] | null;
+    createMultipleFiles: (Files_files)[];
   }
 
   export interface CreateFileInput {    
@@ -31,10 +29,6 @@ export interface Files_files {
     lastModifiedDate: string;
     clientSideChecksum: unknown;
     fileName: string;
-  }
-
-  export interface FilesVariables {    
-    input: CreateFileInput
   }
 
   export interface MultipleFilesVariables {


### PR DESCRIPTION
Get a UUID from the database for each file, and use it as the filename when uploading the file to S3.

This will allow backend file checks and the file export task to link files in the API with files in S3.

It also means that we don't have to encode file names that contain characters that aren't allowed in S3.

We'll need to deploy this at the same time as the API change: https://github.com/nationalarchives/tdr-prototype-sangria/pull/13