### PR TITLE
Add upload progress counters and fix some upload performance issues

### DIFF
--- a/js-src/aws/MetadataUpload.ts
+++ b/js-src/aws/MetadataUpload.ts
@@ -44,14 +44,14 @@ function AddFiles(fileInputs: CreateFileInput[]) {
 }
 
 export const uploadFileMetadata = async (files: File[]): Promise<UploadableFile[]> => {
-    //Retrieve the necessary file info
-    const filesInfo = files.map(
-        async file => {
-            return await getFileInfo(<TdrFile>file)
-        }
-    );
-    const p = await Promise.all(filesInfo);
-    const metadataUploadResponse = (await AddFiles(p)).data;
+    const filesInfo = [];
+
+    for (const file of files) {
+        const fileInfo = await getFileInfo(<TdrFile>file);
+        filesInfo.push(fileInfo);
+    }
+
+    const metadataUploadResponse = (await AddFiles(filesInfo)).data;
 
     if (!metadataUploadResponse) {
         throw "No data in metadata upload response";

--- a/js-src/aws/MetadataUpload.ts
+++ b/js-src/aws/MetadataUpload.ts
@@ -43,12 +43,14 @@ function AddFiles(fileInputs: CreateFileInput[]) {
     );
 }
 
-export const uploadFileMetadata = async (files: File[]): Promise<UploadableFile[]> => {
+export const uploadFileMetadata = async (files: File[], incrementFileCount: () => void): Promise<UploadableFile[]> => {
     const filesInfo = [];
 
     for (const file of files) {
         const fileInfo = await getFileInfo(<TdrFile>file);
         filesInfo.push(fileInfo);
+
+        incrementFileCount();
     }
 
     const metadataUploadResponse = (await AddFiles(filesInfo)).data;

--- a/js-src/aws/s3Upload.ts
+++ b/js-src/aws/s3Upload.ts
@@ -12,7 +12,7 @@ export interface UploadableFile {
     file: File
 }
 
-export const uploadFiles = (files: UploadableFile[]) => {
+export const uploadFiles = (files: UploadableFile[], incrementFileCount: () => void) => {
     const currentUser = getCurrentUser();
     
     if(!currentUser) {
@@ -45,6 +45,8 @@ export const uploadFiles = (files: UploadableFile[]) => {
             // Await so that files are uploaded one-by-one, rather than in parallel. Parallel uploads crash the browser
             // when the files are very large.
             await uploadFile(s3, bucket, fileDetails.id, parentFolder, fileDetails.file);
+
+            incrementFileCount();
         }
     });
 };


### PR DESCRIPTION
Add counters to show the progress of metadata extraction (including checksum calculation) and file uploads.

It's a very basic UI to help us test the upload performance. We can replace the counters with nicer progress bars later:

![Screenshot from 2019-09-05 09-44-55](https://user-images.githubusercontent.com/754712/64326549-171ea480-cfc2-11e9-8db6-6395372c398b.png)

Also fix a couple of performance issues by calculating metadata sequentially rather than in parallel, and uploading files sequentially too. The parallelisation caused Firefox to crash when calculating checksums for hundreds of files, or when uploading multiple very large files.

These changes fix the checksum calculation, and improve the upload performance in Firefox.

Despite the improvement, Firefox on my machine still crashes after uploading about six or seven 600 MB files, which we'll need to look into further.