### PR TITLE
Start export task when the user confirms the transfer

### DIFF
--- a/app/auth/Authorisers.scala
+++ b/app/auth/Authorisers.scala
@@ -13,7 +13,7 @@ object Authorisers {
 
   case class IsConsignmentCreator @Inject ()(client: GraphQLClientProvider, implicit val ec: ExecutionContext) extends Authorization[User, CookieAuthenticator] {
     override def isAuthorized[B](user: User, authenticator: CookieAuthenticator)(implicit request: Request[B]): Future[Boolean] = {
-      val graphqlClient = client.graphqlClient(List())
+      val graphqlClient = client.graphqlClient
       val vars = getConsignmentForCreator.Variables(request.getQueryString("consignmentId").get.toInt, user.email)
       graphqlClient.query[getConsignmentForCreator.Data, getConsignmentForCreator.Variables](getConsignmentForCreator.document, vars).result.map {
         case Right(r) => r.data.getConsignmentForCreator.isDefined

--- a/app/auth/PasswordDao.scala
+++ b/app/auth/PasswordDao.scala
@@ -29,7 +29,7 @@ class PasswordDao @Inject()(client: GraphQLClientProvider)(implicit ec: Executio
   }
 
   override def add(loginInfo: LoginInfo, authInfo: PasswordInfo): Future[PasswordInfo] = {
-    val passwordInput = PasswordInput(loginInfo.providerKey, authInfo.hasher, authInfo.password)
+    val passwordInput = PasswordInput(loginInfo.providerKey, authInfo.hasher, authInfo.password, authInfo.salt)
     val vars: addPassword.Variables = addPassword.Variables(passwordInput)
 
     graphqlClient.query[addPassword.Data, addPassword.Variables](addPassword.document, vars).result.map {
@@ -39,7 +39,7 @@ class PasswordDao @Inject()(client: GraphQLClientProvider)(implicit ec: Executio
   }
 
   override def update(loginInfo: LoginInfo, authInfo: PasswordInfo): Future[PasswordInfo] = {
-    val passwordInput = PasswordInput(loginInfo.providerKey, authInfo.hasher, authInfo.password)
+    val passwordInput = PasswordInput(loginInfo.providerKey, authInfo.hasher, authInfo.password, authInfo.salt)
     val vars: updatePassword.Variables = updatePassword.Variables(passwordInput)
     graphqlClient.query[updatePassword.Data, updatePassword.Variables](updatePassword.document, vars).result.map {
       case Right(_) => PasswordInfo(authInfo.hasher, authInfo.password, authInfo.salt)

--- a/app/auth/PasswordDao.scala
+++ b/app/auth/PasswordDao.scala
@@ -18,7 +18,7 @@ import scala.reflect.ClassTag
 class PasswordDao @Inject()(client: GraphQLClientProvider)(implicit ec: ExecutionContext, implicit val classTag: ClassTag[PasswordInfo])
   extends DelegableAuthInfoDAO[PasswordInfo] {
 
-  val graphqlClient: TdrGraphQLClient = client.graphqlClient(List())
+  val graphqlClient: TdrGraphQLClient = client.graphqlClient
 
   override def find(loginInfo: LoginInfo): Future[Option[PasswordInfo]] = {
     val vars: findPassword.Variables = findPassword.Variables(loginInfo.providerKey)

--- a/app/auth/TotpDao.scala
+++ b/app/auth/TotpDao.scala
@@ -19,7 +19,7 @@ import scala.reflect.ClassTag
 class TotpDao @Inject()(client: GraphQLClientProvider)(implicit ec: ExecutionContext, implicit val classTag: ClassTag[GoogleTotpInfo])
   extends DelegableAuthInfoDAO[GoogleTotpInfo]  {
 
-  val graphqlClient: TdrGraphQLClient = client.graphqlClient(List())
+  val graphqlClient: TdrGraphQLClient = client.graphqlClient
 
   override def find(loginInfo: LoginInfo): Future[Option[GoogleTotpInfo]] = {
     val vars = findTotp.Variables(loginInfo.providerKey)

--- a/app/auth/UserService.scala
+++ b/app/auth/UserService.scala
@@ -26,7 +26,7 @@ class UserService @Inject()(client: GraphQLClientProvider,
 {
 
 
-  val graphqlClient: TdrGraphQLClient = client.graphqlClient(List())
+  val graphqlClient: TdrGraphQLClient = client.graphqlClient
 
   override def retrieve(loginInfo: LoginInfo): Future[Option[User]] = {
     val vars = getUser.Variables(loginInfo.providerKey, loginInfo.providerID)

--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -140,7 +140,7 @@ class AuthController @Inject()(controllerComponents: ControllerComponents,
   }
 
   def resetPassword(email: String, token: String) = Action.async { implicit request =>
-    val graphqlClient = client.graphqlClient(List())
+    val graphqlClient = client.graphqlClient
     val vars = isPasswordTokenValid.Variables(email, token)
     graphqlClient.query[isPasswordTokenValid.Data, isPasswordTokenValid.Variables](isPasswordTokenValid.document, vars).result.map {
       case Right(r) if r.data.isPasswordTokenValid =>  Ok(views.html.resetPassword(ResetPasswordForm.form, email))

--- a/app/controllers/AuthController.scala
+++ b/app/controllers/AuthController.scala
@@ -46,7 +46,7 @@ class AuthController @Inject()(controllerComponents: ControllerComponents,
   def processLoginAttempt: Action[AnyContent] = Action.async { implicit request: Request[AnyContent] =>
 
     val errorFunction: Form[LoginData] => Future[Result] = { formWithErrors: Form[LoginData] =>
-      Future.apply(BadRequest(views.html.login(formWithErrors)))
+      Future.successful(BadRequest(views.html.login(formWithErrors)))
     }
 
     val successFunction: LoginData => Future[Result] = { user: LoginData =>

--- a/app/controllers/CreateConsignmentController.scala
+++ b/app/controllers/CreateConsignmentController.scala
@@ -28,10 +28,10 @@ class CreateConsignmentController @Inject()(
 
   def submit() = silhouette.UserAwareAction.async { implicit request =>
     request.identity.map(id => {
-      val appSyncClient = client.graphqlClient
+      val graphQlClient = client.graphqlClient
       val form = CreateConsignmentData.form.bindFromRequest
       val vars = createConsignment.Variables(form.get.consignmentName,form.get.seriesId,id.email,form.get.transferringBody)
-      appSyncClient.query[createConsignment.Data, createConsignment.Variables](createConsignment.document, vars).result.map {
+      graphQlClient.query[createConsignment.Data, createConsignment.Variables](createConsignment.document, vars).result.map {
         case Right(r) =>
           Redirect(routes.UploadController.index(r.data.createConsignment.id))
         case Left(e) => InternalServerError(e.errors.toString())

--- a/app/controllers/CreateConsignmentController.scala
+++ b/app/controllers/CreateConsignmentController.scala
@@ -28,7 +28,7 @@ class CreateConsignmentController @Inject()(
 
   def submit() = silhouette.UserAwareAction.async { implicit request =>
     request.identity.map(id => {
-      val appSyncClient = client.graphqlClient(List())
+      val appSyncClient = client.graphqlClient
       val form = CreateConsignmentData.form.bindFromRequest
       val vars = createConsignment.Variables(form.get.consignmentName,form.get.seriesId,id.email,form.get.transferringBody)
       appSyncClient.query[createConsignment.Data, createConsignment.Variables](createConsignment.document, vars).result.map {
@@ -37,9 +37,5 @@ class CreateConsignmentController @Inject()(
         case Left(e) => InternalServerError(e.errors.toString())
       }
     }).get
-
-
   }
-
-
 }

--- a/app/controllers/CreateSeriesController.scala
+++ b/app/controllers/CreateSeriesController.scala
@@ -39,7 +39,7 @@ class CreateSeriesController @Inject()(
     val successFunction: CreateSeriesData => Future[Result] = { data: CreateSeriesData =>
       val createSeriesInput = CreateSeriesInput(data.seriesName, data.seriesDescription)
 
-      val graphQlClient = client.graphqlClient(List())
+      val graphQlClient = client.graphqlClient
 
       graphQlClient.query[CreateSeries.CreateSeries.Data, CreateSeries.CreateSeries.Variables](CreateSeries.CreateSeries.document,
         CreateSeries.CreateSeries.Variables(createSeriesInput)).result.map(result => result match {

--- a/app/controllers/CreateSeriesController.scala
+++ b/app/controllers/CreateSeriesController.scala
@@ -34,7 +34,7 @@ class CreateSeriesController @Inject()(
   def submit() = Action.async { implicit request: Request[AnyContent] =>
 
     val errorFunction: Form[CreateSeriesData] => Future[Result] = { formWithErrors: Form[CreateSeriesData] =>
-      Future.apply(BadRequest(views.html.createSeries(formWithErrors)))
+      Future.successful(BadRequest(views.html.createSeries(formWithErrors)))
     }
     val successFunction: CreateSeriesData => Future[Result] = { data: CreateSeriesData =>
       val createSeriesInput = CreateSeriesInput(data.seriesName, data.seriesDescription)

--- a/app/controllers/FileStatusController.scala
+++ b/app/controllers/FileStatusController.scala
@@ -14,7 +14,7 @@ class FileStatusController @Inject()(client: GraphQLClientProvider,
                                     )(implicit val ex: ExecutionContext) extends AbstractController(cc) {
 
   def getFileStatus(consignmentId: Int) = Action.async  { implicit request: Request[AnyContent] =>
-    val appSyncClient = client.graphqlClient(List())
+    val appSyncClient = client.graphqlClient
     appSyncClient.query[Data, Variables](document,Variables(consignmentId)).result.map {
         case Right(r) => Ok(views.html.fileStatus(r.data.getFileChecksStatus, consignmentId))
         case Left(ex) => InternalServerError(ex.errors.toString())
@@ -24,7 +24,7 @@ class FileStatusController @Inject()(client: GraphQLClientProvider,
   implicit val writes = Json.writes[GetFileChecksStatus]
 
   def getFileStatusApi(consignmentId: Int) = Action.async  { implicit request: Request[AnyContent] =>
-    val appSyncClient = client.graphqlClient(List())
+    val appSyncClient = client.graphqlClient
     appSyncClient.query[Data, Variables](document,Variables(consignmentId)).result.map {
       case Right(r) => println(Json.toJson(r.data.getFileChecksStatus)); Ok(Json.toJson(r.data.getFileChecksStatus))
       case Left(ex) => InternalServerError(ex.errors.toString())

--- a/app/controllers/FileStatusController.scala
+++ b/app/controllers/FileStatusController.scala
@@ -14,8 +14,8 @@ class FileStatusController @Inject()(client: GraphQLClientProvider,
                                     )(implicit val ex: ExecutionContext) extends AbstractController(cc) {
 
   def getFileStatus(consignmentId: Int) = Action.async  { implicit request: Request[AnyContent] =>
-    val appSyncClient = client.graphqlClient
-    appSyncClient.query[Data, Variables](document,Variables(consignmentId)).result.map {
+    val graphQlClient = client.graphqlClient
+    graphQlClient.query[Data, Variables](document,Variables(consignmentId)).result.map {
         case Right(r) => Ok(views.html.fileStatus(r.data.getFileChecksStatus, consignmentId))
         case Left(ex) => InternalServerError(ex.errors.toString())
       }
@@ -24,8 +24,8 @@ class FileStatusController @Inject()(client: GraphQLClientProvider,
   implicit val writes = Json.writes[GetFileChecksStatus]
 
   def getFileStatusApi(consignmentId: Int) = Action.async  { implicit request: Request[AnyContent] =>
-    val appSyncClient = client.graphqlClient
-    appSyncClient.query[Data, Variables](document,Variables(consignmentId)).result.map {
+    val graphQlClient = client.graphqlClient
+    graphQlClient.query[Data, Variables](document,Variables(consignmentId)).result.map {
       case Right(r) => println(Json.toJson(r.data.getFileChecksStatus)); Ok(Json.toJson(r.data.getFileChecksStatus))
       case Left(ex) => InternalServerError(ex.errors.toString())
     }

--- a/app/controllers/ReviewController.scala
+++ b/app/controllers/ReviewController.scala
@@ -20,10 +20,10 @@ class ReviewController @Inject()(
   def index(consignmentId: Int) = Action.async {
     implicit request =>
 
-      val appSyncClient = client.graphqlClient
+      val graphQlClient = client.graphqlClient
 
-      val consignmentDetails =  appSyncClient.query[getConsignment.Data, getConsignment.Variables](getConsignment.document, getConsignment.Variables(consignmentId)).result
-      val fileDetails = appSyncClient.query[getFileChecksStatus.Data, getFileChecksStatus.Variables](getFileChecksStatus.document, getFileChecksStatus.Variables(consignmentId)).result
+      val consignmentDetails =  graphQlClient.query[getConsignment.Data, getConsignment.Variables](getConsignment.document, getConsignment.Variables(consignmentId)).result
+      val fileDetails = graphQlClient.query[getFileChecksStatus.Data, getFileChecksStatus.Variables](getFileChecksStatus.document, getFileChecksStatus.Variables(consignmentId)).result
 
       for {
         consignment <-consignmentDetails

--- a/app/controllers/ReviewController.scala
+++ b/app/controllers/ReviewController.scala
@@ -20,7 +20,7 @@ class ReviewController @Inject()(
   def index(consignmentId: Int) = Action.async {
     implicit request =>
 
-      val appSyncClient = client.graphqlClient(List())
+      val appSyncClient = client.graphqlClient
 
       val consignmentDetails =  appSyncClient.query[getConsignment.Data, getConsignment.Variables](getConsignment.document, getConsignment.Variables(consignmentId)).result
       val fileDetails = appSyncClient.query[getFileChecksStatus.Data, getFileChecksStatus.Variables](getFileChecksStatus.document, getFileChecksStatus.Variables(consignmentId)).result

--- a/app/controllers/ReviewController.scala
+++ b/app/controllers/ReviewController.scala
@@ -1,35 +1,84 @@
 package controllers
 
+import com.mohiva.play.silhouette.api.Silhouette
 import graphql.GraphQLClientProvider
 import graphql.codegen.GetConsignment.getConsignment
+import graphql.codegen.GetConsignment.getConsignment.GetConsignment
 import graphql.codegen.GetFileStatus.getFileChecksStatus
+import graphql.codegen.GetFileStatus.getFileChecksStatus.GetFileChecksStatus
 import javax.inject.{Inject, _}
+import model.ReviewData
 import play.api.Configuration
+import play.api.data.Form
+import play.api.data.Forms.{mapping, text}
 import play.api.mvc._
+import utils.DefaultEnv
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 
 @Singleton
 class ReviewController @Inject()(
                                   client: GraphQLClientProvider,
                                   controllerComponents: ControllerComponents,
+                                  silhouette: Silhouette[DefaultEnv],
                                   configuration: Configuration)(
                                   implicit val ex: ExecutionContext) extends AbstractController(controllerComponents) with play.api.i18n.I18nSupport {
 
-  def index(consignmentId: Int) = Action.async {
+  val form = Form(
+    mapping(
+      "confirmRecordTransfer" -> text
+        .verifying("Must answer yes", s => hasAgreed(s)),
+      "confirmOpen" -> text
+        .verifying("Must answer yes", s => hasAgreed(s)),
+      "confirmTnaOwnership" -> text
+        .verifying("Must answer yes", s => hasAgreed(s)),
+    )(ReviewData.apply)(ReviewData.unapply)
+  )
+
+  def index(consignmentId: Int) = silhouette.SecuredAction.async {
     implicit request =>
-
-      val graphQlClient = client.graphqlClient
-
-      val consignmentDetails =  graphQlClient.query[getConsignment.Data, getConsignment.Variables](getConsignment.document, getConsignment.Variables(consignmentId)).result
-      val fileDetails = graphQlClient.query[getFileChecksStatus.Data, getFileChecksStatus.Variables](getFileChecksStatus.document, getFileChecksStatus.Variables(consignmentId)).result
-
-      for {
-        consignment <-consignmentDetails
-        files <- fileDetails
-      } yield {
-        Ok(views.html.review(consignment.right.get.data.getConsignment.get, files.right.get.data.getFileChecksStatus))
-      }
+      getDetailsToReview(consignmentId).map(reviewDetails =>
+        Ok(views.html.review(reviewDetails.consignment, reviewDetails.fileChecks, form))
+      )
   }
+
+  def submit(consignmentId: Int) = silhouette.SecuredAction.async { implicit request: Request[AnyContent] =>
+
+    val errorFunction: Form[ReviewData] => Future[Result] = { formWithErrors: Form[ReviewData] =>
+      getDetailsToReview(consignmentId).map(reviewDetails =>
+        BadRequest(views.html.review(reviewDetails.consignment, reviewDetails.fileChecks, formWithErrors))
+      )
+    }
+    val successFunction: ReviewData => Future[Result] = { formData: ReviewData =>
+      Future.apply(Redirect(routes.TransferConfirmationController.index()))
+    }
+
+    val formValidationResult: Form[ReviewData] = form.bindFromRequest
+
+    formValidationResult.fold(
+      errorFunction,
+      successFunction
+    )
+  }
+
+  private def hasAgreed(s: String): Boolean = {
+    s.equals("yes")
+  }
+
+  private def getDetailsToReview(consignmentId: Int): Future[ConsignmentReview] = {
+    val graphQlClient = client.graphqlClient
+
+    val consignmentDetails =  graphQlClient.query[getConsignment.Data, getConsignment.Variables](getConsignment.document, getConsignment.Variables(consignmentId)).result
+    val fileDetails = graphQlClient.query[getFileChecksStatus.Data, getFileChecksStatus.Variables](getFileChecksStatus.document, getFileChecksStatus.Variables(consignmentId)).result
+
+    for {
+      consignment <- consignmentDetails
+      files <- fileDetails
+    } yield {
+      ConsignmentReview(consignment.right.get.data.getConsignment.get, files.right.get.data.getFileChecksStatus)
+    }
+  }
+
+  case class ConsignmentReview(consignment: GetConsignment, fileChecks: GetFileChecksStatus)
 }

--- a/app/controllers/SeriesDetailsController.scala
+++ b/app/controllers/SeriesDetailsController.scala
@@ -35,7 +35,7 @@ class SeriesDetailsController @Inject()(
 
   def index() = Action.async { implicit request: Request[AnyContent] =>
 
-    val graphQlClient = client.graphqlClient(List())
+    val graphQlClient = client.graphqlClient
 
     graphQlClient.query[GetAllSeries.getAllSeries.Data](GetAllSeries.getAllSeries.document).result.map(result => result match {
       case Right(r) => Ok(views.html.seriesDetails(r.data.getAllSeries, selectedSeriesForm))

--- a/app/controllers/ServiceAgreementsController.scala
+++ b/app/controllers/ServiceAgreementsController.scala
@@ -41,7 +41,7 @@ class ServiceAgreementsController @Inject()(controllerComponents: ControllerComp
   def submit() = Action.async { implicit request: Request[AnyContent] =>
 
     val errorFunction: Form[ServiceAgreementsData] => Future[Result] = { formWithErrors: Form[ServiceAgreementsData] =>
-      Future.apply(BadRequest(views.html.serviceAgreements(formWithErrors, options)))
+      Future.successful(BadRequest(views.html.serviceAgreements(formWithErrors, options)))
     }
     val successFunction: ServiceAgreementsData => Future[Result] = { formData: ServiceAgreementsData =>
       println("++++SERVICE AGREEMENT START++++")
@@ -53,7 +53,7 @@ class ServiceAgreementsController @Inject()(controllerComponents: ControllerComp
       println("DRO Sensitivity: " + formData.droSensitivity)
       println("++++SERVICE AGREEMENT END++++")
 
-      Future.apply(Redirect(routes.SeriesDetailsController.index()))
+      Future.successful(Redirect(routes.SeriesDetailsController.index()))
     }
 
     val formValidationResult: Form[ServiceAgreementsData] = form.bindFromRequest

--- a/app/controllers/ServiceAgreementsController.scala
+++ b/app/controllers/ServiceAgreementsController.scala
@@ -7,7 +7,7 @@ import play.api.data.Form
 import play.api.data.Forms._
 import play.api.mvc._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class ServiceAgreementsController @Inject()(controllerComponents: ControllerComponents,
@@ -38,12 +38,12 @@ class ServiceAgreementsController @Inject()(controllerComponents: ControllerComp
   }
 
   //Only print information to console to show form works
-  def submit() = Action.async { implicit request: Request[AnyContent] =>
+  def submit() = Action { implicit request: Request[AnyContent] =>
 
-    val errorFunction: Form[ServiceAgreementsData] => Future[Result] = { formWithErrors: Form[ServiceAgreementsData] =>
-      Future.successful(BadRequest(views.html.serviceAgreements(formWithErrors, options)))
+    val errorFunction: Form[ServiceAgreementsData] => Result = { formWithErrors: Form[ServiceAgreementsData] =>
+      BadRequest(views.html.serviceAgreements(formWithErrors, options))
     }
-    val successFunction: ServiceAgreementsData => Future[Result] = { formData: ServiceAgreementsData =>
+    val successFunction: ServiceAgreementsData => Result = { formData: ServiceAgreementsData =>
       println("++++SERVICE AGREEMENT START++++")
       println("Public Record: " + formData.publicRecord)
       println("Crown Copyright: " + formData.crownCopyright)
@@ -53,7 +53,7 @@ class ServiceAgreementsController @Inject()(controllerComponents: ControllerComp
       println("DRO Sensitivity: " + formData.droSensitivity)
       println("++++SERVICE AGREEMENT END++++")
 
-      Future.successful(Redirect(routes.SeriesDetailsController.index()))
+      Redirect(routes.SeriesDetailsController.index())
     }
 
     val formValidationResult: Form[ServiceAgreementsData] = form.bindFromRequest

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -46,7 +46,7 @@ class UploadController @Inject()(
         Future.apply(InternalServerError(errors.toString()))
       },
       fileInputs => {
-        val appSyncClient = client.graphqlClient(List())
+        val appSyncClient = client.graphqlClient
 
         appSyncClient.query[Data, Variables](document, Variables(fileInputs.data)).result.map {
           case Right(r) =>
@@ -55,10 +55,8 @@ class UploadController @Inject()(
             Ok(Json.toJson(output))
           case Left(ex) => InternalServerError(ex.errors.toString())
         }
-
       }
     )
-
   }
 
   def upload(consignmentId: Int) = silhouette.SecuredAction(isConsignmentCreator) { implicit request =>
@@ -91,5 +89,4 @@ class UploadController @Inject()(
   implicit val fileInputReads: Reads[FileInputs] = Json.reads[FileInputs]
   implicit val temporaryCredentialsWrites: OWrites[TemporaryCredentials] = Json.writes[TemporaryCredentials]
   implicit val outputWrites: OWrites[Output] = Json.writes[Output]
-
 }

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -43,7 +43,7 @@ class UploadController @Inject()(
     val result = request.body.validate[FileInputs]
     result.fold(
       errors => {
-        Future.apply(InternalServerError(errors.toString()))
+        Future.successful(InternalServerError(errors.toString()))
       },
       fileInputs => {
         val graphQlClient = client.graphqlClient

--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -46,9 +46,9 @@ class UploadController @Inject()(
         Future.apply(InternalServerError(errors.toString()))
       },
       fileInputs => {
-        val appSyncClient = client.graphqlClient
+        val graphQlClient = client.graphqlClient
 
-        appSyncClient.query[Data, Variables](document, Variables(fileInputs.data)).result.map {
+        graphQlClient.query[Data, Variables](document, Variables(fileInputs.data)).result.map {
           case Right(r) =>
             val pathToId: Map[String, String] = r.data.createMultipleFiles map (f => f.path.toString -> f.id.toString) toMap
             val output: Output = Output(pathToId, getTemporaryCredentials, s"tdr-upload-files-$environment")

--- a/app/graphql/GraphQLClientProvider.scala
+++ b/app/graphql/GraphQLClientProvider.scala
@@ -10,7 +10,6 @@ import graphql.tdr._
 import javax.inject.Inject
 import play.api.Configuration
 
-import scala.collection.immutable.Seq
 import scala.concurrent.Future
 
 class GraphQLClientProvider @Inject()(
@@ -28,9 +27,9 @@ class GraphQLClientProvider @Inject()(
       http.outgoingConnectionHttps(uri.authority.host.address(), uri.effectivePort)
     }
 
-  def graphqlClient(oathHeaders: Seq[HttpHeader]): TdrGraphQLClient = {
+  def graphqlClient: TdrGraphQLClient = {
     if (uri.scheme == "http") {
-      TdrGraphQLClient( uri, oathHeaders)
+      TdrGraphQLClient(uri)
     }
     else {
       TdrGraphQLClient(configuration)

--- a/app/graphql/mutations/ConfirmTransfer.graphql
+++ b/app/graphql/mutations/ConfirmTransfer.graphql
@@ -1,0 +1,3 @@
+mutation confirmTransfer ($id: Int!) {
+    confirmTransfer(id: $id)
+}

--- a/app/graphql/tdr/TdrBackenClientGraphQL.scala
+++ b/app/graphql/tdr/TdrBackenClientGraphQL.scala
@@ -1,18 +1,17 @@
 package graphql.tdr
 
 import akka.actor.ActorSystem
-
-import scala.collection.immutable.Seq
-import scala.concurrent.Future
 import akka.http.scaladsl.model._
 import akka.stream.ActorMaterializer
 import com.github.jarlakxen.drunk.backend.AkkaHttpBackend
 
-class TdrBackendClientGraphQL(uri: Uri, oathHeaders: Seq[HttpHeader]) extends TdrBackendClient {
+import scala.concurrent.Future
+
+class TdrBackendClientGraphQL(uri: Uri) extends TdrBackendClient {
 
   implicit val as: ActorSystem = ActorSystem("GraphQLClient")
   implicit val mat: ActorMaterializer = ActorMaterializer()
-  val backend = AkkaHttpBackend(uri, oathHeaders)
+  val backend = AkkaHttpBackend(uri)
 
   def send(body: String): Future[(Int, String)] = {
     backend.send(body)

--- a/app/graphql/tdr/TdrGraphQLClient.scala
+++ b/app/graphql/tdr/TdrGraphQLClient.scala
@@ -23,27 +23,17 @@
 
 package graphql.tdr
 
-import play.api.Configuration
-import javax.inject.Inject
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http.OutgoingConnection
-import akka.http.scaladsl.model.{HttpHeader, HttpRequest, HttpResponse, Uri}
-import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.Flow
+import akka.http.scaladsl.model.Uri
+import com.github.jarlakxen.drunk.extensions.{GraphQLExtensions, NoExtensions}
+import com.github.jarlakxen.drunk.{ast => _, _}
 import io.circe._
 import io.circe.parser._
-import sangria._
+import play.api.Configuration
 import sangria.ast.Document
 import sangria.introspection._
 import sangria.marshalling.circe._
 import sangria.parser.QueryParser
-import ca.ryangreen.apigateway.generic.{GenericApiGatewayClientBuilder, GenericApiGatewayRequestBuilder, GenericApiGatewayResponse}
-import com.github.jarlakxen.drunk.GraphQLClient.GraphQLResponse
-import com.github.jarlakxen.drunk.{ast => _, _}
-import com.github.jarlakxen.drunk.extensions.{GraphQLExtensions, NoExtensions}
 
-import scala.collection.immutable
-import scala.collection.immutable.Seq
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util._
 
@@ -171,7 +161,7 @@ object TdrGraphQLClient {
 
   def apply(configuration: Configuration) = new TdrGraphQLClient(new TdrSignRequestClient(configuration))
 
-  def apply(uri: Uri, oathHeaders: Seq[HttpHeader]) =  new TdrGraphQLClient(new TdrBackendClientGraphQL(uri, oathHeaders))
+  def apply(uri: Uri) =  new TdrGraphQLClient(new TdrBackendClientGraphQL(uri))
 
   // Work arround for Scala 2.11
   implicit class Either212[+A, +B](either: Either[A, B]) {

--- a/app/model/ReviewData.scala
+++ b/app/model/ReviewData.scala
@@ -1,0 +1,3 @@
+package model
+
+case class ReviewData(confirmRecordTransfer: String, confirmOpen: String, confirmTnaOwnership: String)

--- a/app/views/review.scala.html
+++ b/app/views/review.scala.html
@@ -1,4 +1,7 @@
-@(consignment:graphql.codegen.GetConsignment.getConsignment.GetConsignment, files: graphql.codegen.GetFileStatus.getFileChecksStatus.GetFileChecksStatus)
+@import helper._
+@import viewsapi.FormFunctions._
+
+@(consignment:graphql.codegen.GetConsignment.getConsignment.GetConsignment, files: graphql.codegen.GetFileStatus.getFileChecksStatus.GetFileChecksStatus, reviewform: Form[model.ReviewData])(implicit messages: Messages)
 
 @main("Review") {
     @defining(play.core.PlayVersion.current) { version =>
@@ -55,43 +58,47 @@
 
                 </div>
 
-                <!-- Confirmation Checkboxes -->
-                <fieldset class="govuk-fieldset" aria-describedby="confirm-transfer-checks">
-                    <div class="govuk-form-group">
+                @form(action = routes.ReviewController.submit(consignment.id)) {
 
-                        <div class="govuk-checkboxes govuk-checkboxes--small">
-                            <div class="govuk-checkboxes__item">
-                                <input required class="govuk-checkboxes__input" id="tbt" name="confirm-transfer" type="checkbox" value="toBeTransferred">
-                                <label class="govuk-label govuk-checkboxes__label" for="tbt">
-                                    @files.totalFiles records are selected to be transferred.
-                                </label>
-                            </div>
-                            <div class="govuk-checkboxes__item">
-                                <input required class="govuk-checkboxes__input" id="open" name="confirm-transfer" type="checkbox" value="openRecords">
-                                <label class="govuk-label govuk-checkboxes__label" for="open">
-                                    I confirm that all records are open.
-                                </label>
-                            </div>
-                            <div class="govuk-checkboxes__item">
-                                <input required class="govuk-checkboxes__input" id="owner" name="confirm-transfer" type="checkbox" value="ownershipTNA">
-                                <label class="govuk-label govuk-checkboxes__label" for="owner">
-                                    I confirm that I am transferring ownership to The National Archives.
-                                </label>
+                    <!-- Confirmation Checkboxes -->
+                    <fieldset class="govuk-fieldset" aria-describedby="confirm-transfer-checks">
+                        <div class="govuk-form-group">
+                            <div class="govuk-checkboxes govuk-checkboxes--small">
+                                @inputSingleCheckbox(
+                                    reviewform("confirmRecordTransfer"),
+                                    '_label -> s"${files.totalFiles} records are selected to be transferred.",
+                                    '_value -> "yes",
+                                    '_smallCheckbox -> true,
+                                    requiredInputArg -> true
+                                )
+                                @inputSingleCheckbox(
+                                    reviewform("confirmOpen"),
+                                    '_label -> "I confirm that all records are open.",
+                                    '_value -> "yes",
+                                    '_smallCheckbox -> true,
+                                    requiredInputArg -> true
+                                )
+                                @inputSingleCheckbox(
+                                    reviewform("confirmTnaOwnership"),
+                                    '_label -> "I confirm that I am transferring ownership to The National Archives.",
+                                    '_value -> "yes",
+                                    '_smallCheckbox -> true,
+                                    requiredInputArg -> true
+                                )
                             </div>
                         </div>
+                    </fieldset>
+
+                    <!-- Buttons -->
+                    <div class="govuk-form-group">
+                        <a href="@routes.DashboardController.index" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                            Cancel
+                        </a>
+                        <button class="govuk-button" type="submit" data-module="govuk-button" role="button">
+                            Transfer
+                        </button>
                     </div>
-                </fieldset>
-
-                <!-- Buttons -->
-                <div class="govuk-form-group">
-                    <a href="@routes.DashboardController.index" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-                        Cancel
-                    </a>
-                    <a href="#" role="button" draggable="false" class="govuk-button" data-module="govuk-button">
-                        Transfer
-                    </a>
-                </div>
-
+                }
             </div>
         </div>
     }

--- a/conf/routes
+++ b/conf/routes
@@ -20,6 +20,8 @@ GET     /createSeries                       controllers.CreateSeriesController.i
 +nocsrf
 POST    /createSeries/submit                controllers.CreateSeriesController.submit()
 GET     /reviewTransfer                     controllers.ReviewController.index(consignmentId: Int)
++nocsrf
+POST    /reviewTransfer/submit              controllers.ReviewController.submit(consignmentId: Int)
 GET     /upload                             controllers.UploadController.index(consignmentId: Int)
 GET     /createConsignment                  controllers.CreateConsignmentController.index(seriesId: Int)
 +nocsrf

--- a/conf/schema.graphql
+++ b/conf/schema.graphql
@@ -1,9 +1,10 @@
 type Consignment {
   id: Int!
   name: String!
-  series: Series!
   creator: String!
   transferringBody: String!
+  series: Series!
+  files: [File!]!
 }
 
 input CreateFileInput {
@@ -18,19 +19,6 @@ input CreateFileInput {
 input CreateSeriesInput {
   name: String!
   description: String!
-}
-
-input UserInput {
-  firstName: String!
-  lastName: String!
-  email: String!
-  providerId: String!
-}
-
-input PasswordInput {
-  providerKey: String!
-  hasher: String!
-  password: String!
 }
 
 type File {
@@ -59,22 +47,36 @@ type FileStatus {
   antivirusStatus: String!
 }
 
-type FileProgress {
-  totalComplete: Int!
-  totalFiles: Int!
-  error: Boolean!
+scalar Instant
+
+type Mutation {
+  createSeries(createSeriesInput: CreateSeriesInput!): Series!
+  createConsignment(name: String!, seriesId: Int!, creator: String!, transferringBody: String!): Consignment!
+  createFile(createFileInput: CreateFileInput!): File!
+  updateServerSideFileChecksum(id: UUID!, checksum: String!): Boolean!
+  updateClientSideFileChecksum(id: UUID!, checksum: String!): Boolean!
+  updateVirusCheck(id: UUID!, status: String!): Boolean!
+  updateFileFormat(id: UUID!, pronomId: String!): Boolean!
+  createMultipleFiles(createFileInputs: [CreateFileInput!]!): [File!]!
+  createUser(userData: UserInput!): User
+  addPassword(passwordInput: PasswordInput!): PasswordInfo
+  updatePassword(passwordInput: PasswordInput!): Int!
+  removePassword(providerKey: String!): Int!
+  addTotp(totp: TotpInfoInput!): TotpInfo
+  updateTotp(totp: TotpInfoInput!): Int!
+  removeTotp(providerKey: String!): Int!
+  createPasswordResetToken(email: String!): PasswordResetToken
+  confirmTransfer(id: Int!): Boolean!
 }
 
-type User {
-  id: Int!
-  firstName: String!
-  lastName: String!
-  email: String!
-  providerId: String!
+type PasswordInfo {
+  hasher: String!
+  password: String!
+  salt: String
+}
+
+input PasswordInput {
   providerKey: String!
-}
-
-type Password {
   hasher: String!
   password: String!
   salt: String
@@ -85,17 +87,38 @@ type PasswordResetToken {
   token: String!
 }
 
-input TotpInfoInput {
-  providerKey: String!
-  sharedKey: String!
-  scratchCodes: [TotpScratchCodesInput!]!
+type Query {
+  getAllSeries: [Series!]!
+  getConsignments: [Consignment!]!
+  getSeriesForCreator(seriesId: Int!, creator: String!): Series
+  getConsignmentForCreator(id: Int!, creator: String!): Consignment
+  getConsignment(id: Int!): Consignment
+  getFile(id: UUID!): File
+  getFiles: [File!]!
+  getFileChecksStatus(id: Int!): FileCheckStatus!
+  getUser(providerKey: String!, providerId: String!): User
+  findPassword(providerKey: String!): PasswordInfo
+  findTotp(providerKey: String!): TotpInfo
+  isPasswordTokenValid(email: String!, token: String!): Boolean!
 }
 
-type TotpInfoOutput {
+type Series {
+  id: Int!
+  name: String!
+  description: String!
+}
+
+type TotpInfo {
   id: Int!
   providerKey: String!
   sharedKey: String!
   scratchCodes: [TotpScratchCodesOuput!]!
+}
+
+input TotpInfoInput {
+  providerKey: String!
+  sharedKey: String!
+  scratchCodes: [TotpScratchCodesInput!]!
 }
 
 input TotpScratchCodesInput {
@@ -111,46 +134,20 @@ type TotpScratchCodesOuput {
   salt: String
 }
 
-scalar Instant
-
-type Mutation {
-  createSeries(createSeriesInput: CreateSeriesInput!): Series!
-  createConsignment(name: String!, seriesId: Int!, creator: String!, transferringBody: String!): Consignment!
-  createFile(createFileInput: CreateFileInput!): File!
-  updateServerSideFileChecksum(id: UUID!, checksum: String!): Boolean!
-  updateClientSideFileChecksum(id: UUID!, checksum: String!): Boolean!
-  updateVirusCheck(id: UUID!, status: String!): Boolean!
-  updateFileFormat(id: UUID!, pronomId: String!): Boolean!
-  createMultipleFiles(createFileInputs: [CreateFileInput!]!): [File!]!
-  createUser(userData: UserInput!): User
-  addPassword(passwordInput: PasswordInput!): Password
-  updatePassword(passwordInput: PasswordInput!): Int
-  removePassword(providerKey: String!): Int
-  createPasswordResetToken(email: String!): PasswordResetToken
-  addTotp(totp: TotpInfoInput!): TotpInfoOutput
-  updateTotp(totp: TotpInfoInput!): Int!
-  removeTotp(providerKey: String!): Int!
-}
-
-type Query {
-  getAllSeries: [Series!]!
-  getConsignments: [Consignment!]!
-  getConsignment(id: Int!): Consignment
-  getFile(id: UUID!): File
-  getFiles: [File!]!
-  getSeriesForCreator(seriesId: Int!, creator: String!): Series
-  getUser(providerKey: String!, providerId: String!): User
-  findPassword(providerKey: String!): Password
-  getConsignmentForCreator(id: Int!, creator: String!): Consignment
-  isPasswordTokenValid(email: String!, token: String!): Boolean!
-  findTotp(providerKey: String!): TotpInfoOutput
-  getFileChecksStatus(id: Int!): FileCheckStatus!
-}
-
-type Series {
-  id: Int!
-  name: String!
-  description: String!
-}
-
 scalar UUID
+
+type User {
+  id: Int!
+  firstName: String!
+  lastName: String!
+  email: String!
+  providerId: String!
+  providerKey: String!
+}
+
+input UserInput {
+  firstName: String!
+  lastName: String!
+  email: String!
+  providerId: String!
+}


### PR DESCRIPTION
When the user fills out the confirmation form, call the API to trigger the consignment export and show the user the "Transfer complete" page. There's an open question about whether we should show the user a transfer progress page instead, but we'll implement that later if necessary.

There are a few refactoring commits before the main change, so it's probably easiest to review commit-by-commit.

This is a draft because it shouldn't be merged until https://github.com/nationalarchives/tdr-prototype-sangria/pull/25 is deployed.