### PR TITLE
Increase the S3 credential expiry time

### DIFF
--- a/app/controllers/UploadController.scala
+++ b/app/controllers/UploadController.scala
@@ -84,7 +84,7 @@ class UploadController @Inject()(
 
 
     val sessionTokenRequest = new GetSessionTokenRequest()
-    sessionTokenRequest.setDurationSeconds(7200)
+    sessionTokenRequest.setDurationSeconds(36000)
     val getSessionResult = tokenClient.getSessionToken(sessionTokenRequest)
     val credentials = getSessionResult.getCredentials
     TemporaryCredentials(credentials.getAccessKeyId, credentials.getSecretAccessKey, credentials.getSessionToken)


### PR DESCRIPTION
Increase the lifetime of the credentials used to upload files to S3 from 2 hours to 10 hours to let us finish the performance testing measurements.

This is fine for the prototype because it won't be handling sensitive files. In Beta, we should reduce the expiry time and refresh the credentials.