### PR TITLE
Calculate checksum incrementally

### DIFF
--- a/conf/schema.graphql
+++ b/conf/schema.graphql
@@ -10,7 +10,7 @@ type Consignment {
 input CreateFileInput {
   path: String!
   consignmentId: Int!
-  fileSize: Int!
+  fileSize: Long!
   lastModifiedDate: Instant!
   fileName: String!
   clientSideChecksum: String!
@@ -27,7 +27,7 @@ type File {
   consignmentId: Int!
   fileStatus: FileStatus!
   pronomId: String
-  fileSize: Int!
+  fileSize: Long!
   lastModifiedDate: Instant!
   fileName: String!
 }

--- a/js-src/upload/checksum.ts
+++ b/js-src/upload/checksum.ts
@@ -1,0 +1,34 @@
+export const generateHash: (file: File) => Promise<string> = file => {
+    const hashStart = new Date().getTime();
+
+    const crypto = self.crypto.subtle;
+    const fileReader = new FileReader();
+    fileReader.readAsArrayBuffer(file);
+    return new Promise(resolve => {
+        fileReader.onload = async function() {
+            const fileReaderResult = fileReader.result;
+            if (fileReaderResult instanceof ArrayBuffer) {
+                const buffer = await crypto.digest("SHA-256", fileReaderResult);
+
+                if (file.size > 1000000) {
+                    const hashEnd = new Date().getTime();
+                    console.log(
+                        `Calculated hash for ${file.size} byte file ${hashEnd -
+                        hashStart} ms`
+                    );
+                }
+
+                resolve(hexString(buffer));
+            }
+        };
+    });
+};
+
+const hexString = (buffer: ArrayBuffer) => {
+    const byteArray = new Uint8Array(buffer);
+    const hexCodes = [...byteArray].map(value => {
+        const hexCode = value.toString(16);
+        return hexCode.padStart(2, "0");
+    });
+    return hexCodes.join("");
+};

--- a/js-src/upload/index.ts
+++ b/js-src/upload/index.ts
@@ -1,5 +1,6 @@
 import Axios from "axios";
 import * as S3 from "aws-sdk/clients/s3";
+import {generateHash} from "./checksum";
 
 interface HTMLInputTarget extends EventTarget {
     files?: InputElement;
@@ -33,41 +34,6 @@ export interface IWebkitEntry extends DataTransferItem {
     fullPath: string;
     file: (success: (file: File) => void) => void;
 }
-
-const hexString = (buffer: ArrayBuffer) => {
-    const byteArray = new Uint8Array(buffer);
-    const hexCodes = [...byteArray].map(value => {
-        const hexCode = value.toString(16);
-        return hexCode.padStart(2, "0");
-    });
-    return hexCodes.join("");
-};
-
-export const generateHash: (file: File) => Promise<string> = file => {
-    const hashStart = new Date().getTime();
-
-    const crypto = self.crypto.subtle;
-    const fileReader = new FileReader();
-    fileReader.readAsArrayBuffer(file);
-    return new Promise(resolve => {
-        fileReader.onload = async function() {
-            const fileReaderResult = fileReader.result;
-            if (fileReaderResult instanceof ArrayBuffer) {
-                const buffer = await crypto.digest("SHA-256", fileReaderResult);
-
-                if (file.size > 1000000) {
-                    const hashEnd = new Date().getTime();
-                    console.log(
-                        `Calculated hash for ${file.size} byte file ${hashEnd -
-                            hashStart} ms`
-                    );
-                }
-
-                resolve(hexString(buffer));
-            }
-        };
-    });
-};
 
 const upload: () => void = () => {
     const uploadForm: HTMLFormElement | null = document.querySelector(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1405,6 +1405,12 @@
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
     },
+    "asmcrypto.js": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/asmcrypto.js/-/asmcrypto.js-2.3.2.tgz",
+      "integrity": "sha512-3FgFARf7RupsZETQ1nHnhLUUvpcttcCq1iZCaVAbJZbCZ5VNRrNyvpDyHTOb0KC3llFcsyOT/a99NZcCbeiEsA==",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/nationalarchives/tdr-prototype-mvc#readme",
   "devDependencies": {
+    "asmcrypto.js": "^2.3.2",
     "@babel/core": "^7.5.0",
     "@babel/preset-env": "^7.5.0",
     "@types/jest": "^24.0.16",


### PR DESCRIPTION
Use the asmCrypto.js library to calculate a file's checksum incrementally, by loading it into memory in chunks rather than reading the entire file at once.

This is slower than using SubtleCrypto, which uses low-level functions built into the browser, but SubtleCrypto needs the full contents of a file which limits the size of the files that we can process.

Also update the GraphQL schema to support larger file sizes.