### PR TITLE
Fix bug which caused polling to carry on too long

### DIFF
--- a/app/views/fileStatus.scala.html
+++ b/app/views/fileStatus.scala.html
@@ -1,85 +1,106 @@
 @import graphql.codegen.GetFileStatus.getFileChecksStatus.GetFileChecksStatus
 @(status: GetFileChecksStatus, consignmentId: Int)(implicit messages: Messages)
 
+
+@errorClass() = @{
+if(status.virusErrors.size == 0 && status.checksumErrors.size == 0) {
+"hide"
+}
+}
+
+@completeClass() = @{
+if(status.percentage != 100 || status.virusErrors.size > 0 || status.checksumErrors.size > 0) {
+"hide"
+}
+}
+
+@progressBarClass = @{
+if(status.percentage == 100 || status.virusErrors.size > 0 || status.checksumErrors.size > 0) {
+"hide"
+}
+}
+
+@virusErrorClass = @{
+if(status.virusErrors.size == 0) {
+"hide"
+}
+}
+
+@checksumErrorClass = @{
+if(status.checksumErrors.size == 0) {
+"hide"
+}
+}
+
+
+
     @main("FileStatus") {
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-two-thirds">
+
+                <!-- Progress indicator -->
+                <span class="govuk-caption-xl">Step 4 of 5</span>
+                <!-- Headline -->
+                <h3 class="govuk-heading-xl">@messages("filestatus.title")</h3>
 
 
-        @defining(if(status.virusErrors.size > 0 || status.checksumErrors.size > 0) "" else " hide") { errorClass =>
+                <div class="file-status">
 
-            @defining(if(status.percentage == 100 && !(status.virusErrors.size > 0 || status.checksumErrors.size > 0) && status.percentage > 0) "" else " hide") { completeClass =>
-                @defining(if((status.percentage < 100 && !(status.virusErrors.size > 0 || status.checksumErrors.size > 0)) || status.percentage == 0) "" else " hide") { progressBarClass =>
+                    <div class="error @errorClass">
+                        <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+                            <h2 class="govuk-error-summary__title" id="error-summary-title">
+                                There is a problem
+                            </h2>
+                            <div class="govuk-error-summary__body">
+                                <p class="govuk-body">@messages("filestatus.error.general")</p>
+                                <p id="virus-errors" class="govuk-body @virusErrorClass">@messages("filestatus.error.virus")</p>
+                                @for(e <- status.virusErrors) {
+                                    <p>@e</p>
+                                }
+                                <p id="checksum-errors" class="govuk-body @checksumErrorClass">@messages("filestatus.error.checksum")</p>
+                                @for(e <- status.checksumErrors) {
+                                    <p>@e</p>
+                                }
 
-                    <div class="govuk-grid-row">
-                        <div class="govuk-grid-column-two-thirds">
-                
-                            <!-- Progress indicator -->
-                            <span class="govuk-caption-xl">Step 4 of 5</span>
-                            <!-- Headline -->
-                            <h3 class="govuk-heading-xl">@messages("filestatus.title")</h3>
-
-
-                            <div class="file-status">
-
-                                <div class="error @errorClass">
-                                    <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-                                        <h2 class="govuk-error-summary__title" id="error-summary-title">
-                                            There is a problem
-                                        </h2>
-                                        <div class="govuk-error-summary__body">
-                                            <p class="govuk-body">@messages("filestatus.error.general")</p>
-                                            @if(status.virusErrors.nonEmpty) {
-                                                <p class="govuk-body">@messages("filestatus.error.virus")</p>
-                                                @for(e <- status.virusErrors) {
-                                                    <p>@e</p>
-                                                }
-                                            }
-                                            @if(status.checksumErrors.nonEmpty) {
-                                                <p class="govuk-body">@messages("filestatus.error.checksum")</p>
-                                                @for(e <- status.checksumErrors) {
-                                                    <p>@e</p>
-                                                }
-                                            }
-                                        </div>
-                                    </div>
-
-                                    <a href="@routes.DashboardController.index()" role="button" draggable="false" class="govuk-button govuk-button--primary" data-module="govuk-button">
-                                        Start again
-                                    </a>
-
-                                </div>
-
-                                <div class="progress-complete-container @completeClass">
-                                    <div id="success-summary" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
-                                        <h2 class="govuk-error-summary__title" id="error-summary-title">
-                                            @messages("filestatus.success")
-                                        </h2>
-                                        <div class="govuk-error-summary__body">
-                                            <p class="govuk-body">@messages("filestatus.success.filecount", status.totalFiles)</p>
-                                            <p class="govuk-body">@messages("filestatus.success.review")</p>
-                                        </div>
-                                    </div>
-
-                                    <!-- Buttons -->
-                                    <div class="govuk-form-group">
-                                        <a href="@routes.DashboardController.index" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
-                                                Cancel
-                                        </a>
-                                        <a href="@routes.ReviewController.index(consignmentId)" role="button" draggable="false" class="govuk-button govuk-button--primary" data-module="govuk-button">
-                                            @messages("filestatus.success.confirm")
-                                        </a>
-                                    </div>
-                                </div>
-
-                                <div class="progress-container @progressBarClass">
-                                    <progress class="status-progress" value="@status.percentage" max="100"></progress>
-                                    <span class="status-progress-label">@status.percentage%</span>
-                                </div>
-                                
                             </div>
-                        
+                        </div>
+
+                        <a href="@routes.DashboardController.index()" role="button" draggable="false" class="govuk-button govuk-button--primary" data-module="govuk-button">
+                            Start again
+                        </a>
+
+                    </div>
+
+                    <div class="progress-complete-container @completeClass">
+                        <div id="success-summary" class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="govuk-error-summary">
+                            <h2 class="govuk-error-summary__title" id="error-summary-title">
+                                @messages("filestatus.success")
+                            </h2>
+                            <div class="govuk-error-summary__body">
+                                <p class="govuk-body">@messages("filestatus.success.filecount", status.totalFiles)</p>
+                                <p class="govuk-body">@messages("filestatus.success.review")</p>
+                            </div>
+                        </div>
+
+                        <!-- Buttons -->
+                        <div class="govuk-form-group">
+                            <a href="@routes.DashboardController.index" role="button" draggable="false" class="govuk-button govuk-button--secondary" data-module="govuk-button">
+                                    Cancel
+                            </a>
+                            <a href="@routes.ReviewController.index(consignmentId)" role="button" draggable="false" class="govuk-button govuk-button--primary" data-module="govuk-button">
+                                @messages("filestatus.success.confirm")
+                            </a>
                         </div>
                     </div>
-                }
-            }
-        }
+
+                    <div class="progress-container @progressBarClass">
+                        <progress class="status-progress" value="@status.percentage" max="100"></progress>
+                        <span class="status-progress-label">@status.percentage%</span>
+                    </div>
+
+                </div>
+
+            </div>
+        </div>
+
     }

--- a/js-src/fileStatus/index.ts
+++ b/js-src/fileStatus/index.ts
@@ -20,7 +20,7 @@ const updateFileStatuses: () => void = () => {
                 console.log(data.data)
                 const statusProgress: HTMLProgressElement | null = document.querySelector(".status-progress")
                 const statusProgressLabel: HTMLProgressElement | null = document.querySelector(".status-progress-label")
-                const { percentage, totalFiles, virusErrors, checksumErrors } = data.data
+                const { percentage, virusErrors, checksumErrors } = data.data
                 const error = virusErrors.length || checksumErrors.length
                 if (statusProgress !== null && statusProgressLabel !== null) {
                     statusProgress.value = percentage
@@ -30,7 +30,6 @@ const updateFileStatuses: () => void = () => {
                 const errorContainer: HTMLDivElement | null = document.querySelector(".error")
                 if (percentage === 100 && !error) {
                     const progressCompleteContainer: HTMLDivElement | null = document.querySelector(".progress-complete-container")
-                    const completeMessage: HTMLSpanElement | null = document.querySelector(".complete-message")
                     if (progressContainer && progressCompleteContainer) {
                         progressCompleteContainer.classList.remove('hide')
                         progressContainer.classList.add('hide')
@@ -38,10 +37,34 @@ const updateFileStatuses: () => void = () => {
                     if (errorContainer) {
                         errorContainer.classList.add("hide")
                     }
-                    completeMessage!.innerText = `${totalFiles} files have been successfully uploaded`
                     clearInterval(pollingInterval)
                 }
                 if (error && errorContainer && progressContainer) {
+                    const virusErrorMessage: HTMLDivElement | null = document.querySelector("#virus-errors");
+                    const checksumErrorMessage: HTMLDivElement | null = document.querySelector("#checksum-errors");
+                    const errorDiv: HTMLDivElement | null = document.querySelector(".govuk-error-summary__body");
+                    if (virusErrors.length && virusErrorMessage && !virusErrorMessage.children.length) {
+                        virusErrorMessage.classList.remove("hide");
+                        checksumErrorMessage!.classList.add("hide")
+                        for(const error of virusErrors) {
+                            const pElement = document.createElement("p")
+                            const textNode = document.createTextNode(error);
+                            pElement.appendChild(textNode)
+                            errorDiv!.append(pElement)
+                            
+                        }
+                    }
+                    if(checksumErrors.length && checksumErrorMessage && !checksumErrorMessage.children.length) {
+                        checksumErrorMessage.classList.remove("hide");
+                        virusErrorMessage!.classList.add("hide")
+                        for(const error of checksumErrors) {
+                            const pElement = document.createElement("p")
+                            const textNode = document.createTextNode(error);
+                            pElement.appendChild(textNode)
+                            checksumErrorMessage!.appendChild(pElement)
+                            errorDiv!.append(pElement)
+                        }
+                    }
                     errorContainer.classList.remove("hide");
                     progressContainer.classList.add("hide");
                     clearInterval(pollingInterval)


### PR DESCRIPTION
There was an error where we were trying to set the inner text
on an element which didn't support it. This meant that the next
line which stopped the polling wasn't working. There's no reason
to update this div so I've deleted this line.

There was second issue where the javascript wasn't updating the
error page correctly if there were virus or checksum errors. I've
fixed this in the javascript and tidied up the .scala.html file.