### PR TITLE
Temporarily revert WebAssembly progress monitor

### DIFF
--- a/js-src/upload/index.ts
+++ b/js-src/upload/index.ts
@@ -185,11 +185,9 @@ const onDrop: (e: DragEvent) => void = async e => {
 const getFileInfo: (
     tdrFile: TdrFile
 ) => Promise<CreateFileInput> = async tdrFile => {
-    const progress: (percentage: number) => void = percentage =>
-        console.log(percentage);
     let clientSideChecksum;
     if (wasmSupported) {
-        clientSideChecksum = await wasm.generate_checksum(tdrFile, progress);
+        clientSideChecksum = await wasm.generate_checksum(tdrFile);
     } else {
         clientSideChecksum = await generateHash(tdrFile);
     }


### PR DESCRIPTION
Remove the console logs which happen when the WebAssembly checksum calculator reports a progress update.

The version of the WebAssembly library which supports the `progress` argument (version 0.1.5) has not yet been published to npm, so the local npm build is failing. Removing the `progress` argument means we can use the latest npm version (0.1.4).