### PR TITLE
Fix checksum calculation in Edge

### DIFF
--- a/js-src/bootstrap.ts
+++ b/js-src/bootstrap.ts
@@ -1,2 +1,0 @@
-// @ts-ignore
-import("./index.ts").catch(e => console.error("Error importing `index.ts`:", e));

--- a/js-src/index.ts
+++ b/js-src/index.ts
@@ -1,10 +1,45 @@
 import { updateFileStatuses } from "./fileStatus";
-import { upload } from "./upload";
+import {ChecksumCalculator, upload} from "./upload";
+
+const wasmSupported = (() => {
+    try {
+        if (
+            typeof WebAssembly === "object" &&
+            typeof WebAssembly.instantiate === "function"
+        ) {
+            const module = new WebAssembly.Module(
+                Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00)
+            );
+            if (module instanceof WebAssembly.Module)
+                return (
+                    new WebAssembly.Instance(module) instanceof
+                    WebAssembly.Instance
+                );
+        }
+    } catch (e) {}
+    return false;
+})();
 
 window.onload = function() {
+    if (wasmSupported) {
+        // @ts-ignore
+        import("@nationalarchives/checksum-calculator")
+            .then(checksumModule => {
+                renderModules(checksumModule);
+            })
+            .catch(e => {
+                console.error("Error importing checksum module:", e);
+                renderModules()
+            });
+    } else {
+        renderModules();
+    }
+};
+
+const renderModules = (checksumCalculator?: ChecksumCalculator) => {
     const uploadContainer: HTMLDivElement | null = document.querySelector(".upload-form");
     if (uploadContainer) {
-        upload();
+        upload(checksumCalculator);
     }
     const fileStatusContainer: HTMLDivElement | null = document.querySelector(".file-status");
     if (fileStatusContainer) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 
 module.exports = {
-  entry: './js-src/bootstrap.ts',
+  entry: './js-src/index.ts',
   output: {
     filename: 'main.js',
     path: path.resolve(__dirname, 'public/javascripts'),


### PR DESCRIPTION
Checksum calculations were failing in Edge because the Rust WebAssembly wrapper depends on `TextDecoder`, which is not supported by the current version of Edge (even though WebAssembly itself is supported):

https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/TextDecoder

This commit fixes the problem by trying to load the WASM module, and falling back to checksums calculated in JavaScript if the module fails to load.

This uses exceptions for control flow, but there's no obvious property to test to be confident that WASM will work, since it may depend on modules other than `TextDecoder` in the future.

A possible alternative would be to polyfill `TextDecoder`, as described here: https://github.com/golang/go/issues/27295#issuecomment-416472615

The polyfill is quite complicated, though, so the JS checksum fallback seems like a better solution, at least for now. We can revisit it if there are major performance problems.