### PR TITLE
Only log checksum progress for large files

### DIFF
--- a/js-src/index.ts
+++ b/js-src/index.ts
@@ -26,6 +26,7 @@ window.onload = function() {
         // @ts-ignore
         import("@nationalarchives/checksum-calculator")
             .then(checksumModule => {
+                console.log("WebAssembly checksum module loaded");
                 renderModules(new ChecksumCalculator(checksumModule));
             })
             .catch(e => {
@@ -33,6 +34,7 @@ window.onload = function() {
                 renderModules(new ChecksumCalculator())
             });
     } else {
+        console.log("WebAssembly not available");
         renderModules(new ChecksumCalculator());
     }
 };

--- a/js-src/index.ts
+++ b/js-src/index.ts
@@ -1,5 +1,6 @@
 import { updateFileStatuses } from "./fileStatus";
-import {ChecksumCalculator, upload} from "./upload";
+import { upload } from "./upload";
+import { ChecksumCalculator } from "./upload/checksum";
 
 const wasmSupported = (() => {
     try {
@@ -25,18 +26,18 @@ window.onload = function() {
         // @ts-ignore
         import("@nationalarchives/checksum-calculator")
             .then(checksumModule => {
-                renderModules(checksumModule);
+                renderModules(new ChecksumCalculator(checksumModule));
             })
             .catch(e => {
                 console.error("Error importing checksum module:", e);
-                renderModules()
+                renderModules(new ChecksumCalculator())
             });
     } else {
-        renderModules();
+        renderModules(new ChecksumCalculator());
     }
 };
 
-const renderModules = (checksumCalculator?: ChecksumCalculator) => {
+const renderModules = (checksumCalculator: ChecksumCalculator) => {
     const uploadContainer: HTMLDivElement | null = document.querySelector(".upload-form");
     if (uploadContainer) {
         upload(checksumCalculator);

--- a/js-src/upload/index.ts
+++ b/js-src/upload/index.ts
@@ -173,8 +173,11 @@ const getFileInfo: (
     useJsForChecksums: boolean,
     checksumCalculator?: ChecksumCalculator
 ) => Promise<CreateFileInput> = async (tdrFile, useJsForChecksums, checksumCalculator) => {
-    const progress: (percentage: number) => void = percentage =>	
-        console.log(percentage);
+    const progress: (percentage: number) => void = percentage => {
+        if (tdrFile.size > 10000000) {
+            console.log(`Progress: ${percentage}%`);
+        }
+    };
     let clientSideChecksum;
     if (checksumCalculator && !useJsForChecksums) {
         clientSideChecksum = await checksumCalculator.generate_checksum(tdrFile, progress);


### PR DESCRIPTION
Remove excessive checksum logging for small files. It makes the logs noisy, and it might even have been slowing down the calculations for consignments with thousands of tiny files.

Also refactor checksum code so that the decision of which process to use (WebAssembly vs JS) is isolated in one file.

Keep the check of the override flag in local storage in the upload module so it is only checked once rather than for every file. This is temporary code anyway, since we only need it for performance testing.