### PR TITLE
Make uploads of client-side metadata batches sequential

### DIFF
--- a/js-src/upload/index.ts
+++ b/js-src/upload/index.ts
@@ -225,16 +225,20 @@ function createBatches(files: CreateFileInput[], batchSize: number) {
     return batches;
 }
 
-function uploadFileData(batches: CreateFileInput[][], consignmentId: number) {
-    const responses = batches.map(async function(value) {
-        return await Axios.post<{}, AxiosResponse>(
+async function uploadFileData(batches: CreateFileInput[][], consignmentId: number) {
+    let responses: AxiosResponse[] = [];
+
+    for (const batch of batches) {
+        const response = await Axios.post<{}, AxiosResponse>(
             `/filedata?consignmentId=${consignmentId}`,
             {
-                data: value
+                data: batch
             }
         );
-    });
-    return Promise.all(responses);
+        responses = responses.concat(response);
+    }
+
+    return responses;
 }
 
 async function processFiles(files: TdrFile[], checksumCalculator: ChecksumCalculator) {


### PR DESCRIPTION
Change the way the frontend sends client-side metadata to the API. Send the batches sequentially rather than in parallel. The parallel requests have been returning 504 errors since we added an index to the file path column in the DB.

These API requests are much quicker than the checksum and file upload steps, so it shouldn't cause a performance problem if we send them sequentially.