### PR TITLE
Trim whitespace from checksum

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ resolvers += Resolver.bintrayRepo("jarlakxen", "maven")
 resolvers += Resolver.jcenterRepo
 
 libraryDependencies ++= Seq(
+  "com.typesafe.akka" %% "akka-actor" % "2.5.26",
   "io.circe" %% "circe-core" %  "0.9.3",
   "io.circe" %% "circe-generic" %  "0.9.3",
   "io.circe" %% "circe-parser" %  "0.9.3",

--- a/js-src/upload/checksum.ts
+++ b/js-src/upload/checksum.ts
@@ -55,5 +55,5 @@ const generateHash: (file: File, handleProgress: (percentage: number) => void) =
     }
 
     const result = sha256.finish().result!;
-    return bytes_to_hex(result);
+    return bytes_to_hex(result).trim();
 };


### PR DESCRIPTION
The JS checksum module was adding an extra leading U+FEFF whitespace character when running in Safari.

If we use asmcrypto.js in Beta, we should track down the reason for the whitespace. For now, just strip out the whitespace so it doesn't break the API call.