### PR TITLE
Remove IE8 version of govuk-frontend

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -8,7 +8,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" media="screen" href='@routes.Assets.versioned("stylesheets/main.css")'>
     <link rel="stylesheet" media="screen" href='@routes.Assets.versioned("stylesheets/govuk-frontend-2.13.0.min.css")'>
-    <link rel="stylesheet" media="screen" href='@routes.Assets.versioned("stylesheets/govuk-frontend-ie8-2.13.0.min.css")'>
     <link rel="stylesheet" media="screen" href='@routes.Assets.versioned("stylesheets/prism.css")'>
     <link rel="shortcut icon" type="image/png" href='@routes.Assets.versioned("images/favicon.png")'>
     <script src="https://code.iconify.design/1/1.0.3/iconify.min.js"></script>


### PR DESCRIPTION
The styles were being loaded in Chrome for Mac, and it was breaking the layout: the main content was being left-aligned rather than centred.

We cannot test this prototype in IE anyway because you cannot upload directories in IE, so it's safe to remove the IE version of govuk-frontend. We can revisit this issue in Beta when we add IE zip-upload support.